### PR TITLE
Fix ensureUrl to work well with http:// input

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,14 @@
+import { ensureUrl } from "./utils";
+
+describe("ensureUrl", () => {
+  const cases = [
+    ["siasky.net", "https://siasky.net"],
+    ["https://siasky.net", "https://siasky.net"],
+    ["http://siasky.net", "http://siasky.net"],
+  ];
+
+  it.each(cases)("('%s') should result in '%s'", (input, expectedResult) => {
+    const result = ensureUrl(input);
+    expect(result).toEqual(expectedResult);
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -69,6 +69,9 @@ export function createFullScreenIframe(
  * @returns - The URL.
  */
 export function ensureUrl(url: string): string {
+  if (url.startsWith("http://")) {
+    return url;
+  }
   return ensurePrefix(url, "https://");
 }
 


### PR DESCRIPTION
# PULL REQUEST

## Overview

Before, an input of `"http://siasky.net"` would result in `"https://http://siasky.net"`.

Now, it will just return `"http://siasky.net"`.